### PR TITLE
Update 37-ipfs-in-web-workers.md

### DIFF
--- a/DEEP_DIVES/37-ipfs-in-web-workers.md
+++ b/DEEP_DIVES/37-ipfs-in-web-workers.md
@@ -5,7 +5,7 @@ Modern web platform offers options for running code off the main thread via [Ded
 ### Problem space
 
 - Browser should act as a single IPFS node rather than each app embedding a separate node.
-- Service Worker's are deactivated when they are not serving requests (& for a good reasons).
+- Service Worker's are deactivated when they are not serving requests (& for good reasons).
 - Safari does not support Shared Workers.
 - Sharing IPFS node across origins is quite an undertaking.
 - Access control (which app gets to read what, or what the write quota should be ?)

--- a/DEEP_DIVES/37-ipfs-in-web-workers.md
+++ b/DEEP_DIVES/37-ipfs-in-web-workers.md
@@ -18,7 +18,7 @@ Reliable IPFS node accessible by web applications across all the mainstream brow
 ## Requirements to consider
 
 - Seamless upgrade - in-browser IPFS node should discover on device IPFS node (e.g IPFS Desktop) and leverage it for networking, more reliable data storage, etc..
-- User Agency - The largerst problems of the web today are: user tracking, data hoarding and lock-in. We should embed user agency into the core of of the ecosystem (IPFS) to build a better web instead of making these problems worse.
+- User Agency - The largest problems of the web today are: user tracking, data hoarding and lock-in. We should embed user agency into the core of the ecosystem (IPFS) to build a better web instead of making these problems worse.
 - Data availablity (sync) - (Centralized) Web is popular because user can pick up a task on a phone where it was left off on the laptop. Within the walled gardens of Google, Github, ${your_favouite_org} users can access their data regardless of the device they're one & we need to provide that level of access as well.
 
 

--- a/DEEP_DIVES/37-ipfs-in-web-workers.md
+++ b/DEEP_DIVES/37-ipfs-in-web-workers.md
@@ -1,6 +1,6 @@
 # IPFS in Web Workers
 
-Modern web platform offers options for running code off the main thread via [Dedicated](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API), [Shared](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker) & [Service](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker) Worker APIs. Each with own quirks and unique benefits. We will explore the benefits of running IPFS node in the woker(s), limitations & current efforts to overcome them.
+Modern web platform offers options for running code off the main thread via [Dedicated](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API), [Shared](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker) & [Service](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker) Worker APIs. Each with it's own quirks and unique benefits. We will explore the benefits of running an IPFS node in the worker(s), limitations & current efforts to overcome them.
 
 ### Problem space
 

--- a/DEEP_DIVES/37-ipfs-in-web-workers.md
+++ b/DEEP_DIVES/37-ipfs-in-web-workers.md
@@ -1,15 +1,30 @@
 # IPFS in Web Workers
 
-Where we are, limitations, known problems. https://github.com/ipfs/in-web-browsers/issues/55
+Modern web platform offers options for running code off the main thread via [Dedicated](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API), [Shared](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker) & [Service](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker) Worker APIs. Each with own quirks and unique benefits. We will explore the benefits of running IPFS node in the woker(s), limitations & current efforts to overcome them.
+
+### Problem space
+
+- Browser should act as a single IPFS node rather than each app embedding a separate node.
+- Service Worker's are deactivated when they are not serving requests (& for a good reasons).
+- Safari does not support Shared Workers.
+- Sharing IPFS node across origins is quite an undertaking.
+- Access control (which app gets to read what, or what the write quota should be ?)
+- IPFS node needs a way to deal with [storage limits](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria#Storage_limits)
 
 ## Goal
 
-<Define what we would get if the Open Problem(s) are solved for this Deep Dive>
+Reliable IPFS node accessible by web applications across all the mainstream browsers.
 
 ## Requirements to consider
 
-<Do we have requirements (i.e. work with 1MM nodes)?>
+- Seamless upgrade - in-browser IPFS node should discover on device IPFS node (e.g IPFS Desktop) and leverage it for networking, more reliable data storage, etc..
+- User Agency - The largerst problems of the web today are: user tracking, data hoarding and lock-in. We should embed user agency into the core of of the ecosystem (IPFS) to build a better web instead of making these problems worse.
+- Data availablity (sync) - (Centralized) Web is popular because user can pick up a task on a phone where it was left off on the laptop. Within the walled gardens of Google, Github, ${your_favouite_org} users can access their data regardless of the device they're one & we need to provide that level of access as well.
+
 
 ## Where to learn about it
 
-<List of talks, links to github issues, code, notes and so on>
+- [IPFS runs as a Service Worker](https://github.com/ipfs/in-web-browsers/issues/55)
+- [Accessing API of remote IPFS node](https://github.com/ipfs/in-web-browsers/issues/137)
+- [ipfs-shipyard/ipfs-service-worker](https://github.com/ipfs-shipyard/ipfs-service-worker)
+- [Lunet](https://github.com/gozala/lunet)

--- a/DEEP_DIVES/37-ipfs-in-web-workers.md
+++ b/DEEP_DIVES/37-ipfs-in-web-workers.md
@@ -19,7 +19,7 @@ Reliable IPFS node accessible by web applications across all the mainstream brow
 
 - Seamless upgrade - in-browser IPFS node should discover on device IPFS node (e.g IPFS Desktop) and leverage it for networking, more reliable data storage, etc..
 - User Agency - The largest problems of the web today are: user tracking, data hoarding and lock-in. We should embed user agency into the core of the ecosystem (IPFS) to build a better web instead of making these problems worse.
-- Data availablity (sync) - (Centralized) Web is popular because user can pick up a task on a phone where it was left off on the laptop. Within the walled gardens of Google, Github, ${your_favouite_org} users can access their data regardless of the device they're one & we need to provide that level of access as well.
+- Data availablity (sync) - (Centralized) Web is popular because user can pick up a task on a phone where it was left off on the laptop. Within the walled gardens of Google, Github, ${your_favouite_org} users can access their data regardless of the device they're on & we need to provide that level of access as well.
 
 
 ## Where to learn about it


### PR DESCRIPTION
@alanshaw please let me know what you think ?

I also would really like to alter a conversation slightly. Often the question is framed as **how do we bring IPFS to the devs** building on it, I think it's more useful to ask **how do we bring core values of IPFS to the users** instead. This reframing often leads to different compromise and IMO prevents us from repeating mistakes of the web we have today. E.g. lunet's objective is not providing a full IPFS node API but rather it is to provide API for apps to read / write data on users behalf such that user can have full access to all of it:
- Choose who to share it with
- Choose which app to use with a dataset
- Data is encryption on user behalf without sharing keys with an apps.

Let me know if you think bringing these constraints is reasonable or if you'd much rather focus on pure limitations of workers.