### PR TITLE
fix: deep dive graduation presentation time

### DIFF
--- a/DEEP_DIVES/README.md
+++ b/DEEP_DIVES/README.md
@@ -39,7 +39,7 @@ On the day, this is how y'all will Deep Dive 🐋:
 
 The next day (graduation day), this is what happens:
 
-1. Each group gets **5 minutes to present your solution**
+1. Each group gets **2 minutes to present a summary of your solution**
 1. You get **one slide** in the shared slide deck
 1. The best solution(s) win an award 🏆
 


### PR DESCRIPTION
5m * 30 = 2.5h

...except we only have 2 hours for the entire graduation ceremony (scheduled from 9:00 - 11:00)!

In this PR I suggest a reduction to 2m presentation time (1h total). Is it too short? How much time do we need for the other items in the graduation cremony?