### PR TITLE
docs: update course b setup instructions for windows

### DIFF
--- a/CORE_AND_ELECTIVE_COURSES/CORE_COURSE_B/README.md
+++ b/CORE_AND_ELECTIVE_COURSES/CORE_COURSE_B/README.md
@@ -32,6 +32,7 @@ Everyone will need a working go 1.12 installation. Beyond that, feel free to stu
 
 ### Preparing for JS
 
+1. Have git installed, [https://git-scm.com/downloads](https://git-scm.com/downloads).
 1. Node.js >= 10 installed
 1. npm >= 6 installed
 1. Download or clone the code at https://github.com/libp2p/js-libp2p-examples, `git clone https://github.com/libp2p/js-libp2p-examples.git`.
@@ -42,5 +43,7 @@ Everyone will need a working go 1.12 installation. Beyond that, feel free to stu
 
 #### Web Browsers
 
-1. Have a Web Browser installed. The chat example was built and tested with [Firefox](https://www.mozilla.org/firefox/new/).
+**Windows Users**: If your npm config is not already set to support bash, you will need to do that for the Web Browser examples. Check out this [Stack Overflow Answer](https://stackoverflow.com/a/46006249) for how to do that. This will enable Parcel to correctly locate the appropriate, nested files.
+
+1. Have the latest version of [Firefox](https://www.mozilla.org/firefox/new/), [Brave](https://brave.com/download/), **or** [Chrome](https://www.google.com/chrome/) installed. Firefox was tested the most during the building of this workshop, so we'd recommend having that installed just in case there is an issue with your preferred browser.
 1. Install dependencies by following the Setup directions at https://github.com/libp2p/js-libp2p-examples/tree/master/chat/browser#setup.


### PR DESCRIPTION
I did a fresh setup of the workshop on a windows laptop that **only** had firefox installed.

I installed:
- VSCode
- git (needed for some node modules)
- node 10.16 (using [nvm-windows](https://github.com/coreybutler/nvm-windows)), which contains npm 6.x

The Bootstrap node and Node.js examples worked immediately. After setting the npm config, as mentioned in the readme update, I was able to get the Browser example running properly.

I also updated the browser list with what I've tested, and mentioned having Firefox installed just in case, as I have tested that on multiple OS's.

