### PR TITLE
Add link to ProtoSchool tutorial

### DIFF
--- a/CORE_AND_ELECTIVE_COURSES/CORE_COURSE_A/README.md
+++ b/CORE_AND_ELECTIVE_COURSES/CORE_COURSE_A/README.md
@@ -127,4 +127,4 @@ Duration: ~20 min
     * Why the MFS root CID changes
         * How propagation up the merkle dag works
         * Where discarded branches go (gc)
-* Intro to the MFS ProtoSchool workshop
+* Intro to the [MFS ProtoSchool tutorial](https://proto.school/#/mutable-file-system)


### PR DESCRIPTION
Linking out to the MFS tutorial on ProtoSchool from the outline of Core Course A where it was used